### PR TITLE
Update for new Wayland default

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -28,5 +28,51 @@ jobs:
       - name: Install Dependencies
         run: npm ci --ignore-scripts
 
-      - name: Run Tests
-        run: npm run test
+      - name: Run Prettier Check
+        id: prettier_check
+        run: |
+          set +e
+          npm run test:format
+          status=$?
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Build Prettier Failure Summary
+        if: steps.prettier_check.outputs.status != '0'
+        run: |
+          npx prettier . --list-different > /tmp/prettier_files.txt
+
+          {
+            echo "### Prettier check failed"
+            echo
+            echo "The following file(s) are not formatted correctly:"
+            echo
+            sed 's/^/- /' /tmp/prettier_files.txt
+            echo
+            echo "To fix locally, run:"
+            echo
+            echo '```bash'
+            echo 'npm run lint'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Build a suggested patch so web-only contributors can see exactly what changed.
+          xargs -a /tmp/prettier_files.txt npx prettier --write
+
+          {
+            echo
+            echo "Suggested patch:"
+            echo
+            echo '```diff'
+            git --no-pager diff -- . | sed -n '1,400p'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail on Prettier Issues
+        if: steps.prettier_check.outputs.status != '0'
+        run: |
+          echo "Formatting check failed. See the job summary for details."
+          exit 1
+
+      - name: Run Spelling Check
+        run: npm run test:spelling

--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -164,9 +164,9 @@ You can start MagicMirror² in client mode by manually running the following
 command with the MagicMirror directory:
 `node clientonly --address 192.168.1.5 --port 8080`
 
-### Wayland
+### X11
 
-If you use Wayland. Run `node --run start:wayland` instead of `node --run start`
+MagicMirror² now uses Wayland by default. If you use X11, run `node --run start:x11` instead of `node --run start`
 to start.
 
 ### Windows


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to reflect that MagicMirror² now uses Wayland as its default runtime environment.
  * X11 users have a designated startup command available for running the application on their system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->